### PR TITLE
Fix build FPGA Vivado

### DIFF
--- a/src/obi_pkg.sv
+++ b/src/obi_pkg.sv
@@ -103,7 +103,16 @@ package obi_pkg;
   endfunction
 
   /// The default OBI bus config.
-  localparam obi_cfg_t ObiDefaultConfig = obi_default_cfg(32, 32, 1, ObiMinimalOptionalConfig);
+  localparam obi_cfg_t ObiDefaultConfig = '{
+      UseRReady: 1'b0,
+      CombGnt: 1'b0,
+      AddrWidth: 32,
+      DataWidth: 32,
+      IdWidth: 1,
+      Integrity: 1'b0,
+      BeFull: 1'b1,
+      OptionalCfg: ObiMinimalOptionalConfig
+  };
 
   function automatic obi_cfg_t mux_grow_cfg(obi_cfg_t ObiCfgIn, int unsigned NumManagers);
     mux_grow_cfg = '{


### PR DESCRIPTION
This PR addresses an issue where the localparam "ObiDefaultConfig" was defined using a function call to obi_default_cfg. However, Vivado does not support this syntax, resulting in the following error during FPGA build:

"obi_default_cfg" is not a valid constant function call.

To resolve this, I removed the function call and directly populated the structure with the necessary values.

This fix is backward compatible