### PR TITLE
Synth fix in obi_cut

### DIFF
--- a/src/obi_cut.sv
+++ b/src/obi_cut.sv
@@ -49,15 +49,12 @@ module obi_cut #(
   logic ready_o;
   logic ready_i;
 
-  generate
-    if (ObiCfg.UseRReady) begin
-      assign ready_o = mgr_port_req_o.rready;
-      assign ready_i = sbr_port_req_i.rready;
-    end
-    else begin
-        assign ready_i = 1'b1;
-    end
-  endgenerate
+  if (ObiCfg.UseRReady) begin : gen_use_rready
+    assign ready_o = mgr_port_req_o.rready;
+    assign ready_i = sbr_port_req_i.rready;
+  end else begin : gen_no_use_rready
+    assign ready_i = 1'b1;
+  end
 
   spill_register #(
     .T      ( obi_r_chan_t ),

--- a/src/obi_cut.sv
+++ b/src/obi_cut.sv
@@ -46,7 +46,18 @@ module obi_cut #(
     .data_o  ( mgr_port_req_o.a   )
   );
 
-  logic unused_rready;
+  logic ready_o;
+  logic ready_i;
+
+  generate
+    if (ObiCfg.UseRReady) begin
+      assign ready_o = mgr_port_req_o.rready;
+      assign ready_i = sbr_port_req_i.rready;
+    end
+    else begin
+        assign ready_i = 1'b1;
+    end
+  endgenerate
 
   spill_register #(
     .T      ( obi_r_chan_t ),
@@ -54,12 +65,12 @@ module obi_cut #(
   ) i_req_r (
     .clk_i,
     .rst_ni,
-    .valid_i (                    mgr_port_rsp_i.rvalid                 ),
-    .ready_o ( ObiCfg.UseRReady ? mgr_port_req_o.rready : unused_rready ),
-    .data_i  (                    mgr_port_rsp_i.r                      ),
-    .valid_o (                    sbr_port_rsp_o.rvalid                 ),
-    .ready_i ( ObiCfg.UseRReady ? sbr_port_req_i.rready : 1'b1          ),
-    .data_o  (                    sbr_port_rsp_o.r                      )
+    .valid_i ( mgr_port_rsp_i.rvalid ),
+    .ready_o ( ready_o               ),
+    .data_i  ( mgr_port_rsp_i.r      ),
+    .valid_o ( sbr_port_rsp_o.rvalid ),
+    .ready_i ( ready_i               ),
+    .data_o  ( sbr_port_rsp_o.r      )
   );
 
 endmodule


### PR DESCRIPTION
```
logic unused_rready;

spill_register #(
    .T      ( obi_r_chan_t ),
    .Bypass ( BypassRsp    )
) i_req_r (
    .clk_i,
    .rst_ni,
    .valid_i (                    mgr_port_rsp_i.rvalid                 ),
    .ready_o ( ObiCfg.UseRReady ? mgr_port_req_o.rready : unused_rready ),
    .data_i  (                    mgr_port_rsp_i.r                      ),
    .valid_o (                    sbr_port_rsp_o.rvalid                 ),
    .ready_i ( ObiCfg.UseRReady ? sbr_port_req_i.rready : 1'b1          ),
    .data_o  (                    sbr_port_rsp_o.r                      )
);
```
This code in ports `ready_o` and `ready_i `of `i_reg_r` was causing issue with Synopsys DC because even if the condition is not true (`ObiCfg.UseRReady == 0`) the compiler tries to access to undefined fields.
The fix is made using a static comparison and assign statements.
```
logic ready_o;
logic ready_i;

if (ObiCfg.UseRReady) begin : gen_use_rready
    assign ready_o = mgr_port_req_o.rready;
    assign ready_i = sbr_port_req_i.rready;
end else begin : gen_no_use_rready
    assign ready_i = 1'b1;
end

spill_register #(
    .T      ( obi_r_chan_t ),
    .Bypass ( BypassRsp    )
) i_req_r (
    .clk_i,
    .rst_ni,
    .valid_i ( mgr_port_rsp_i.rvalid ),
    .ready_o ( ready_o               ),
    .data_i  ( mgr_port_rsp_i.r      ),
    .valid_o ( sbr_port_rsp_o.rvalid ),
    .ready_i ( ready_i               ),
    .data_o  ( sbr_port_rsp_o.r      )
);
```