### PR TITLE
Upstream fixes from Croc SoC

### DIFF
--- a/src/obi_demux.sv
+++ b/src/obi_demux.sv
@@ -16,7 +16,7 @@ module obi_demux #(
   /// The maximum number of outstanding transactions.
   parameter int unsigned       NumMaxTrans = 32'd0,
   /// The type of the port select signal.
-  parameter type               select_t    = logic [$clog2(NumMgrPorts)-1:0]
+  parameter type               select_t    = logic [cf_math_pkg::idx_width(NumMgrPorts)-1:0]
 ) (
   input  logic                       clk_i,
   input  logic                       rst_ni,
@@ -119,7 +119,7 @@ module obi_demux_intf #(
   /// The maximum number of outstanding transactions.
   parameter int unsigned       NumMaxTrans = 32'd0,
   /// The type of the port select signal.
-  parameter type               select_t    = logic [$clog2(NumMgrPorts)-1:0]
+  parameter type               select_t    = logic [cf_math_pkg::idx_width(NumMgrPorts)-1:0]
 ) (
   input logic         clk_i,
   input logic         rst_ni,

--- a/src/obi_err_sbr.sv
+++ b/src/obi_err_sbr.sv
@@ -28,13 +28,13 @@ module obi_err_sbr #(
   logic fifo_full, fifo_empty, fifo_pop;
 
   always_comb begin
+    obi_rsp_o         = '0;
     obi_rsp_o.r.rdata = '0;
     obi_rsp_o.r.rdata = RspData;
     obi_rsp_o.r.rid   = rid;
     obi_rsp_o.r.err   = 1'b1;
-    obi_rsp_o.r.r_optional = '0;
-    obi_rsp_o.gnt = ~fifo_full;
-    obi_rsp_o.rvalid = ~fifo_empty;
+    obi_rsp_o.gnt     = ~fifo_full;
+    obi_rsp_o.rvalid  = ~fifo_empty;
   end
 
   if (ObiCfg.UseRReady) begin : gen_pop_rready

--- a/src/obi_mux.sv
+++ b/src/obi_mux.sv
@@ -45,7 +45,7 @@ module obi_mux #(
     $fatal(1, "unimplemented");
   end
 
-  localparam int unsigned RequiredExtraIdWidth = $clog2(NumSbrPorts);
+  localparam int unsigned RequiredExtraIdWidth = cf_math_pkg::idx_width(NumSbrPorts);
 
   logic [NumSbrPorts-1:0] sbr_ports_req, sbr_ports_gnt;
   sbr_port_a_chan_t [NumSbrPorts-1:0] sbr_ports_a;

--- a/src/obi_sram_shim.sv
+++ b/src/obi_sram_shim.sv
@@ -43,12 +43,14 @@ module obi_sram_shim #(
   assign wdata_o = obi_req_i.a.wdata;
   assign be_o    = obi_req_i.a.be;
 
-  assign obi_rsp_o.gnt     = gnt_i;
-  assign obi_rsp_o.rvalid  = rvalid_q;
-  assign obi_rsp_o.r.rdata = rdata_i;
-  assign obi_rsp_o.r.rid   = id_q;
-  assign obi_rsp_o.r.err   = 1'b0;
-  assign obi_rsp_o.r.r_optional = '0;
+  always_comb begin
+    obi_rsp_o         = '0;
+    obi_rsp_o.gnt     = gnt_i;
+    obi_rsp_o.rvalid  = rvalid_q;
+    obi_rsp_o.r.rdata = rdata_i;
+    obi_rsp_o.r.rid   = id_q;
+    obi_rsp_o.r.err   = 1'b0;
+  end
 
   assign rvalid_d = obi_req_i.req & obi_rsp_o.gnt;
   assign id_d     = obi_req_i.a.aid;

--- a/src/obi_xbar.sv
+++ b/src/obi_xbar.sv
@@ -49,10 +49,10 @@ module obi_xbar #(
 
   input  addr_map_rule_t [NumAddrRules-1:0]   addr_map_i,
   input  logic [NumSbrPorts-1:0]              en_default_idx_i,
-  input  logic [NumSbrPorts-1:0][$clog2(NumMgrPorts)-1:0] default_idx_i
+  input  logic [NumSbrPorts-1:0][cf_math_pkg::idx_width(NumMgrPorts)-1:0] default_idx_i
 );
 
-  logic [NumSbrPorts-1:0][$clog2(NumMgrPorts)-1:0] sbr_port_select;
+  logic [NumSbrPorts-1:0][cf_math_pkg::idx_width(NumMgrPorts)-1:0] sbr_port_select;
 
   // Signals from the demuxes
   sbr_port_obi_req_t [NumSbrPorts-1:0][NumMgrPorts-1:0] sbr_reqs;
@@ -188,7 +188,7 @@ module obi_xbar_intf #(
 
   input  addr_map_rule_t [NumAddrRules-1:0]   addr_map_i,
   input  logic [NumSbrPorts-1:0]              en_default_idx_i,
-  input  logic [NumSbrPorts-1:0][$clog2(NumMgrPorts)-1:0] default_idx_i
+  input  logic [NumSbrPorts-1:0][cf_math_pkg::idx_width(NumMgrPorts)-1:0] default_idx_i
 );
 
   `OBI_TYPEDEF_ALL(sbr_port_obi, SbrPortObiCfg)

--- a/src/test/tb_obi_atop_resolver.sv
+++ b/src/test/tb_obi_atop_resolver.sv
@@ -18,7 +18,7 @@ module tb_obi_atop_resolver;
   localparam int unsigned AddrWidth = 32;
   localparam int unsigned DataWidth = 32;
   localparam int unsigned MgrIdWidth = 5;
-  localparam int unsigned SbrIdWidth = MgrIdWidth+$clog2(NumManagers);
+  localparam int unsigned SbrIdWidth = MgrIdWidth+cf_math_pkg::idx_width(NumManagers);
   localparam int unsigned AUserWidth = 4;
   localparam int unsigned WUserWidth = 2;
   localparam int unsigned RUserWidth = 3;
@@ -213,14 +213,14 @@ module tb_obi_atop_resolver;
   );
 
   atop_golden_mem_pkg::atop_golden_mem #(
-    .ObiAddrWidth ( AddrWidth           ),
-    .ObiDataWidth ( DataWidth           ),
-    .ObiIdWidthM  ( MgrIdWidth          ),
-    .ObiIdWidthS  ( SbrIdWidth          ),
-    .ObiUserWidth ( AUserWidth          ),
-    .NumMgrWidth  ( $clog2(NumManagers) ),
-    .ApplDelay    ( ApplTime            ),
-    .AcqDelay     ( TestTime            )
+    .ObiAddrWidth ( AddrWidth                           ),
+    .ObiDataWidth ( DataWidth                           ),
+    .ObiIdWidthM  ( MgrIdWidth                          ),
+    .ObiIdWidthS  ( SbrIdWidth                          ),
+    .ObiUserWidth ( AUserWidth                          ),
+    .NumMgrWidth  ( cf_math_pkg::idx_width(NumManagers) ),
+    .ApplDelay    ( ApplTime                            ),
+    .AcqDelay     ( TestTime                            )
   ) golden_memory = new(mem_monitor_dv);
   assign mem_monitor_dv.user = '0;
 
@@ -493,7 +493,7 @@ module tb_obi_atop_resolver;
     // SC without acquiring lock -> !exokay
     ///////////////////////////////////////
     assert (randomize(address));
-    address[$clog2(DataWidth/8)-1:0] = '0;
+    address[cf_math_pkg::idx_width(DataWidth/8)-1:0] = '0;
     assert (randomize(data));
     assert (randomize(trans_id));
     // Initialize address
@@ -519,7 +519,7 @@ module tb_obi_atop_resolver;
     // LR/SC sequence -> exokay
     ///////////////////////////
     assert (randomize(address));
-    address[$clog2(DataWidth/8)-1:0] = '0;
+    address[cf_math_pkg::idx_width(DataWidth/8)-1:0] = '0;
     assert (randomize(trans_id));
     // Initialize address
     obi_rand_managers[0].write(address, '1, '0, trans_id, a_optional, rdata, rid, err, r_optional);
@@ -553,7 +553,7 @@ module tb_obi_atop_resolver;
     // LR then different SC -> !exokay
     //////////////////////////////////
     assert (randomize(address));
-    address[$clog2(DataWidth/8)-1:0] = '0;
+    address[cf_math_pkg::idx_width(DataWidth/8)-1:0] = '0;
     assert (randomize(trans_id));
     // Initialize address
     obi_rand_managers[0].write(address, '1, '0, trans_id, a_optional, rdata, rid, err, r_optional);
@@ -568,7 +568,7 @@ module tb_obi_atop_resolver;
 
     do begin
       assert (randomize(address_2));
-      address_2[$clog2(DataWidth/8)-1:0] = '0;
+      address_2[cf_math_pkg::idx_width(DataWidth/8)-1:0] = '0;
     end while (address_2 == address);
     assert (randomize(data));
     a_optional.atop = ATOPSC;
@@ -583,7 +583,7 @@ module tb_obi_atop_resolver;
     // LR, other core store, SC -> !exokay
     //////////////////////////////////////
     assert (randomize(address));
-    address[$clog2(DataWidth/8)-1:0] = '0;
+    address[cf_math_pkg::idx_width(DataWidth/8)-1:0] = '0;
     assert (randomize(trans_id));
     // Initialize address
     obi_rand_managers[0].write(address, '1, '0, trans_id, a_optional, rdata, rid, err, r_optional);

--- a/src/test/tb_obi_xbar.sv
+++ b/src/test/tb_obi_xbar.sv
@@ -17,7 +17,7 @@ module tb_obi_xbar;
   localparam int unsigned AddrWidth = 32;
   localparam int unsigned DataWidth = 32;
   localparam int unsigned MgrIdWidth = 5;
-  localparam int unsigned SbrIdWidth = MgrIdWidth+$clog2(NumManagers);
+  localparam int unsigned SbrIdWidth = MgrIdWidth+cf_math_pkg::idx_width(NumManagers);
   localparam int unsigned AUserWidth = 4;
   localparam int unsigned WUserWidth = 2;
   localparam int unsigned RUserWidth = 3;


### PR DESCRIPTION
1. Replace $clog2 with idx_width function
Where $clog2 is used to calculate an index width, replace it with the ifx_width function from cfg_math_pkg in common_cells.
Fixes the clog2(1) is 0, leading to signals with a negative-width problem.

2. Replace explicit r_optional assignment with defaults
This enables users to use structs without the r_optional signal entirely.
There is a minor functional difference in that potential unassigned signals are now given a default value of 0.