### PR TITLE
Present valid request only on WriteBack state

### DIFF
--- a/src/obi_atop_resolver.sv
+++ b/src/obi_atop_resolver.sv
@@ -378,6 +378,7 @@ module obi_atop_resolver
         mgr_port_req_o.a.be   = '0;
         // serve from register if we cut the path
         if (RegisterAmo) begin
+          mgr_port_req_o.req = (state_q == WriteBackAMO);
           mgr_port_req_o.a.wdata = amo_result_q;
           mgr_port_req_o.a.be = {RiscvWordWidth/8{1'b1}} <<
           (amo_operand_addr_q * RiscvWordWidth/8);

--- a/src/obi_atop_resolver.sv
+++ b/src/obi_atop_resolver.sv
@@ -393,8 +393,8 @@ module obi_atop_resolver
   end
 
   if (RegisterAmo) begin : gen_amo_slice
-    `FFLNR(amo_result_q, amo_result, (state_q == DoAMO), clk_i)
-    `FFLNR(amo_operand_addr_q, amo_operand_addr, (state_q == DoAMO), clk_i)
+    `FFL(amo_result_q, amo_result, (state_q == DoAMO), '0, clk_i, rst_ni)
+    `FFL(amo_operand_addr_q, amo_operand_addr, (state_q == DoAMO), '0, clk_i, rst_ni)
   end else begin : gen_amo_slice
     assign amo_result_q = '0;
     assign amo_operand_addr_q = '0;


### PR DESCRIPTION
The `atop_resolver` outputs a write-back request only in `WriteBack` state. 
Required when the cut path register is enabled.