### PR TITLE
Allow assertions exclusion with a define.

### DIFF
--- a/src/apb_to_obi.sv
+++ b/src/apb_to_obi.sv
@@ -139,7 +139,7 @@ module apb_to_obi #(
   // Assertions
   // ----------
 
-`ifdef OBI_ASSERT_ON
+`ifndef OBI_ASSERTS_OFF
   `ASSERT(penable, obi_phase_q == RESP |-> apb_req_i.penable, clk_i, !rst_ni,
       "APB PENABLE must be asserted during OBI RESP phase!")
   `ASSERT_INIT(no_integrity, !ObiCfg.Integrity,

--- a/src/apb_to_obi.sv
+++ b/src/apb_to_obi.sv
@@ -139,6 +139,7 @@ module apb_to_obi #(
   // Assertions
   // ----------
 
+`ifdef OBI_ASSERT_ON
   `ASSERT(penable, obi_phase_q == RESP |-> apb_req_i.penable, clk_i, !rst_ni,
       "APB PENABLE must be asserted during OBI RESP phase!")
   `ASSERT_INIT(no_integrity, !ObiCfg.Integrity,
@@ -153,5 +154,6 @@ module apb_to_obi #(
       "RDATA width mismatch between APB and OBI ports!")
   `ASSERT_INIT(equal_addr_width, $bits(apb_req_i.paddr) == $bits(obi_req_o.a.addr),
       "Address width mismatch between APB and OBI ports!")
+`endif
 
 endmodule


### PR DESCRIPTION
This PR introduces the `OBI_ASSERT_ON` define to shut down System Verilog assertions in the `apb_2_obi` IP. This became useful when simulating code with Verilator since it complains about:
```
%Error: [...]/apb_to_obi.sv:142:132: Define passed too many arguments: ASSERT
  142 |   ASSERT(penable, obi_phase_q == RESP |-> apb_req_i.penable, clk_i, !rst_ni, "APB PENABLE must be asserted during OBI RESP phase!")
```
It is not exactly clear to me why it complains for this, at the beginning I was supposing that defaulted values in the assertion arguments (like `__desc = ""`) translated in Verilator hardcoding that argument to the default, not allowing an instance override. This does not seem to be the case, I think with other IPs (like `stream_xbar` in the common_cells) this problem does not appear because the assertions are all excluded by default.
This might also be useful in synthesis.