### PR TITLE
obi_atop_resolver: Add comments and use `common_cells` assertions

### DIFF
--- a/Bender.lock
+++ b/Bender.lock
@@ -1,7 +1,7 @@
 packages:
   common_cells:
-    revision: 9afda9abb565971649c2aa0985639c096f351171
-    version: 1.38.0
+    revision: de8742553f36321af3997418cb632907081c273a
+    version: null
     source:
       Git: https://github.com/pulp-platform/common_cells.git
     dependencies:

--- a/Bender.yml
+++ b/Bender.yml
@@ -8,7 +8,7 @@ package:
     - "Michael Rogenmoser <michaero@iis.ee.ethz.ch>"
 
 dependencies:
-  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: 1.38.0 }
+  common_cells: { git: "https://github.com/pulp-platform/common_cells.git", version: de8742553f36321af3997418cb632907081c273a }
   common_verification: { git: "https://github.com/pulp-platform/common_verification.git", version: 0.2.3 }
 
 export_include_dirs:


### PR DESCRIPTION
Minor, non-functional changes to improve code readability and understanding:
- Add comments
- Use enumerated type for lzc's `MODE` parameter
- Use `common_cells` assertions for all checks