### PR TITLE
[Fix] Fix underflow in OBI typedefs

### DIFF
--- a/include/obi/typedef.svh
+++ b/include/obi/typedef.svh
@@ -7,14 +7,16 @@
 `ifndef OBI_TYPEDEF_SVH
 `define OBI_TYPEDEF_SVH
 
+`define OBI_TYPEDEF_MIN_WIDTH(WIDTH) ((WIDTH) > 0 ? (WIDTH) : 1)
+
 `define OBI_TYPEDEF_A_CHAN_T(a_chan_t, ADDR_WIDTH, DATA_WIDTH, ID_WIDTH, a_optional_t) \
   typedef struct packed {                                                              \
-    logic [  ADDR_WIDTH-1:0] addr;                                                     \
-    logic                    we;                                                       \
-    logic [DATA_WIDTH/8-1:0] be;                                                       \
-    logic [  DATA_WIDTH-1:0] wdata;                                                    \
-    logic [    ID_WIDTH-1:0] aid;                                                      \
-    a_optional_t             a_optional;                                               \
+    logic [                      ADDR_WIDTH-1:0] addr;                                 \
+    logic                                        we;                                   \
+    logic [                    DATA_WIDTH/8-1:0] be;                                   \
+    logic [                      DATA_WIDTH-1:0] wdata;                                \
+    logic [`OBI_TYPEDEF_MIN_WIDTH(ID_WIDTH)-1:0] aid;                                  \
+    a_optional_t                                 a_optional;                           \
   } a_chan_t;
 
 `define OBI_TYPEDEF_TYPE_A_CHAN_T(a_chan_t, addr_t, data_t, strb_t, id_t, a_optional_t) \
@@ -37,22 +39,22 @@
 
 `define OBI_TYPEDEF_ALL_A_OPTIONAL(a_optional_t, AUSER_WIDTH, WUSER_WIDTH, MID_WIDTH, ACHK_WIDTH) \
   typedef struct packed {                                                                         \
-    logic [ AUSER_WIDTH-1:0] auser;                                                               \
-    logic [ WUSER_WIDTH-1:0] wuser;                                                               \
-    obi_pkg::atop_t          atop;                                                                \
-    obi_pkg::memtype_t       memtype;                                                             \
-    logic [   MID_WIDTH-1:0] mid;                                                                 \
-    obi_pkg::prot_t          prot;                                                                \
-    logic                    dbg;                                                                 \
-    logic [  ACHK_WIDTH-1:0] achk;                                                                \
+    logic [`OBI_TYPEDEF_MIN_WIDTH(AUSER_WIDTH)-1:0] auser;                                        \
+    logic [`OBI_TYPEDEF_MIN_WIDTH(WUSER_WIDTH)-1:0] wuser;                                        \
+    obi_pkg::atop_t                                 atop;                                         \
+    obi_pkg::memtype_t                              memtype;                                      \
+    logic [  `OBI_TYPEDEF_MIN_WIDTH(MID_WIDTH)-1:0] mid;                                          \
+    obi_pkg::prot_t                                 prot;                                         \
+    logic                                           dbg;                                          \
+    logic [ `OBI_TYPEDEF_MIN_WIDTH(ACHK_WIDTH)-1:0] achk;                                         \
   } a_optional_t;
 
 `define OBI_TYPEDEF_R_CHAN_T(r_chan_t, RDATA_WIDTH, ID_WIDTH, r_optional_t) \
   typedef struct packed {                                                   \
-    logic [RDATA_WIDTH-1:0] rdata;                                          \
-    logic [   ID_WIDTH-1:0] rid;                                            \
-    logic                   err;                                            \
-    r_optional_t            r_optional;                                     \
+    logic [                     RDATA_WIDTH-1:0] rdata;                     \
+    logic [`OBI_TYPEDEF_MIN_WIDTH(ID_WIDTH)-1:0] rid;                       \
+    logic                                        err;                       \
+    r_optional_t                                 r_optional;                \
   } r_chan_t;
 
 `define OBI_TYPEDEF_TYPE_R_CHAN_T(r_chan_t, data_t, id_t, r_optional_t) \
@@ -68,9 +70,9 @@
 
 `define OBI_TYPEDEF_ALL_R_OPTIONAL(r_optional_t, RUSER_WIDTH, RCHK_WIDTH) \
   typedef struct packed {                                                 \
-    logic [RUSER_WIDTH-1:0] ruser;                                        \
-    logic                   exokay;                                       \
-    logic [ RCHK_WIDTH-1:0] rchk;                                         \
+    logic [`OBI_TYPEDEF_MIN_WIDTH(RUSER_WIDTH)-1:0] ruser;                \
+    logic                                           exokay;               \
+    logic [ `OBI_TYPEDEF_MIN_WIDTH(RCHK_WIDTH)-1:0] rchk;                 \
   } r_optional_t;
 
 `define OBI_TYPEDEF_DEFAULT_REQ_T(req_t, a_chan_t) \


### PR DESCRIPTION
Fix underflow in OBI type definitions.

# Probem Description
Many default configs and testbenches set the signal widths of unused optional signals to 0. For some simulators (like VCS), this leads to the following problem:
Because the widths are `unsigned` fields in the `obi_optional_cfg_t`/`obi_cfg_t` structs, the `[x_WIDTH-1:0]` in the type definition results in an underflow due to the unsigned `0-1` and the simulator tries to create a `[2**32-1:0]` sized vector. 

# Proposed Solution

There are multiple ways to solve this problem:
- Convert the width fields in the `obi_optional_cfg_t`/`obi_cfg_t` structs to `int` instead of `int unsigned` types, resulting in `logic [-1:0]` vectors when a signal is not used. However, this does not solve the problem if some of the the typedef macros are called directly and not generated from the config.
- Using `logic [$signed(x_WIDTH)-1:0]` to cast the width inside the typedefs, resulting in `logic [-1:0]` vectors when a signal is not used. 
- Checking if the width is 0 and computing `logic [(x_WIDTH > 0 ? x_WIDTH : 1)-1:0]`, resulting in `logic [0:0]` vectors when a signal is not used. 

For this PR, the last of these solution was implemented, using new macro `OBI_TYPEDEF_MIN_WIDTH`. 